### PR TITLE
LINEからの予約確認が正常に予約情報を取得できな

### DIFF
--- a/backend/momonail_backend_project/settings.py
+++ b/backend/momonail_backend_project/settings.py
@@ -126,13 +126,13 @@ SIMPLE_JWT = {
 }
 
 # 環境変数からCORS許可オリジンを取得
-""" CORS_ALLOWED_ORIGINS_STR = os.environ.get('CORS_ALLOWED_ORIGINS', '')
+CORS_ALLOWED_ORIGINS_STR = os.environ.get('CORS_ALLOWED_ORIGINS', '')
 CORS_ALLOWED_ORIGINS = CORS_ALLOWED_ORIGINS_STR.split(',') if CORS_ALLOWED_ORIGINS_STR.strip() else []
- """
+"""
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
     "http://127.0.0.1:5173",
-]
+]""" 
 
 CORS_ALLOW_METHODS = [
     'DELETE',


### PR DESCRIPTION
顧客の予約日選択画面にてカレンダーのレイアウトがおかし
管理画面ロダイン後自動遷移されな
管理画面のセッション管理をもっと細かく
顧客一覧の検索部をアコーディオン
顧客管理の予約履歴のテープルのレイアウトをスマホ用に修正
予約時の確認画面でメールアドレスと日時部に改行が入ってしまう